### PR TITLE
Improve lexer structure

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -1,79 +1,141 @@
 import enum
 from dataclasses import dataclass
 
+
 class TokenSpec:
     class Type(enum.Enum):
-        # ---------- Palabras clave ----------
-        MAIN   = "main"
-        IF     = "if"
-        ELSE   = "else"
-        WHILE  = "while"
-        EXPORT = "exportar"
-        AS     = "como"
+        # — Palabras clave —
+        MAIN = enum.auto()
+        IF = enum.auto()
+        ELSE = enum.auto()
+        WHILE = enum.auto()
+        EXPORT = enum.auto()
+        AS = enum.auto()
 
-        # ---------- Tipos (solo los necesarios) ----------
-        STRING_TYPE = "string"
-        FLOAT_TYPE  = "float"
-        INT_TYPE    = "int"
-        VIDEO_TYPE  = "video"
-        AUDIO_TYPE  = "audio"
+        # — Tipos de datos —
+        INT_TYPE = enum.auto()
+        FLOAT_TYPE = enum.auto()
+        STRING_TYPE = enum.auto()
+        VIDEO_TYPE = enum.auto()
+        AUDIO_TYPE = enum.auto()
 
-        # ---------- Operadores lógicos ----------
-        NOT = "not"
-        AND = "and"
-        OR  = "or"
+        # — Literales e identificadores —
+        INT_LITERAL = enum.auto()
+        FLOAT_LITERAL = enum.auto()
+        STRING_LITERAL = enum.auto()
+        IDENTIFIER = enum.auto()
 
-        # ---------- Operadores matemáticos ----------
-        ASSIGN = "="
-        PLUS   = "+"
-        MINUS  = "-"
-        MULT   = "*"
-        DIV    = "/"
+        # — Operadores lógicos —
+        NOT = enum.auto()
+        AND = enum.auto()
+        OR = enum.auto()
 
-        # ---------- Comparaciones ----------
-        EQ   = "=="
-        NEQ  = "!="
-        LT   = "<"
-        GT   = ">"
-        LE   = "<="
-        GE   = ">="
+        # — Operadores aritméticos —
+        ASSIGN = enum.auto()  # '='
+        PLUS = enum.auto()    # '+'
+        MINUS = enum.auto()   # '-'
+        MULT = enum.auto()    # '*'
+        DIV = enum.auto()     # '/'
 
-        # ---------- Símbolos ----------
-        COMMENT = "//"
-        LPAREN    = "("
-        RPAREN    = ")"
-        LBRACE    = "{"
-        RBRACE    = "}"
-        LBRACKET  = "["
-        RBRACKET  = "]"
-        COMMA     = ","
-        SEMICOLON = ";"
-        COLON     = ":"
+        # — Comparaciones —
+        EQ = enum.auto()   # '=='
+        NEQ = enum.auto()  # '!='
+        LT = enum.auto()   # '<'
+        GT = enum.auto()   # '>'
+        LE = enum.auto()   # '<='
+        GE = enum.auto()   # '>='
 
-        # ---------- Identificadores y literales ----------
-        IDENTIFIER     = "identifier"
-        INT_LITERAL    = "int_literal"
-        FLOAT_LITERAL  = "float_literal"
-        STRING_LITERAL = "string_literal"
+        # — Símbolos —
+        LPAREN = enum.auto()
+        RPAREN = enum.auto()
+        LBRACE = enum.auto()
+        RBRACE = enum.auto()
+        LBRACKET = enum.auto()
+        RBRACKET = enum.auto()
+        COMMA = enum.auto()
+        SEMICOLON = enum.auto()
+        COLON = enum.auto()
 
-        # ---------- Funciones especiales de video ----------
-        VIDEO_RESIZE         = "@resize"
-        VIDEO_FLIP           = "@flip"
-        VIDEO_VELOCIDAD      = "@velocidad"
-        VIDEO_FADEIN         = "@fadein"
-        VIDEO_FADEOUT        = "@fadeout"
-        VIDEO_SILENCIO       = "@silencio"
-        VIDEO_EXTRAER_AUDIO  = "@extraer_audio"
-        VIDEO_QUITAR_AUDIO   = "@quitar_audio"
-        VIDEO_AGREGAR_MUSICA = "@agregar_musica"
-        VIDEO_CONCATENAR     = "@concatenar"
-        VIDEO_CORTAR         = "@cortar"
+        # — Funciones especiales de video —
+        VIDEO_RESIZE = enum.auto()
+        VIDEO_FLIP = enum.auto()
+        VIDEO_VELOCIDAD = enum.auto()
+        VIDEO_FADEIN = enum.auto()
+        VIDEO_FADEOUT = enum.auto()
+        VIDEO_SILENCIO = enum.auto()
+        VIDEO_EXTRAER_AUDIO = enum.auto()
+        VIDEO_QUITAR_AUDIO = enum.auto()
+        VIDEO_AGREGAR_MUSICA = enum.auto()
+        VIDEO_CONCATENAR = enum.auto()
+        VIDEO_CORTAR = enum.auto()
 
-        # ---------- Especiales ----------
-        EOF   = "eof"
-        ERROR = "error"
+        # — Especiales —
+        EOF = enum.auto()
+        ERROR = enum.auto()
 
-@dataclass
+
+# Mapeo único de lexemas a tipos de token
+LEXEME_TO_TOKEN: dict[str, TokenSpec.Type] = {
+    # keywords
+    "main": TokenSpec.Type.MAIN,
+    "if": TokenSpec.Type.IF,
+    "else": TokenSpec.Type.ELSE,
+    "while": TokenSpec.Type.WHILE,
+    "exportar": TokenSpec.Type.EXPORT,
+    "como": TokenSpec.Type.AS,
+
+    # tipos
+    "int": TokenSpec.Type.INT_TYPE,
+    "float": TokenSpec.Type.FLOAT_TYPE,
+    "string": TokenSpec.Type.STRING_TYPE,
+    "video": TokenSpec.Type.VIDEO_TYPE,
+    "audio": TokenSpec.Type.AUDIO_TYPE,
+
+    # literales lógicos
+    "not": TokenSpec.Type.NOT,
+    "and": TokenSpec.Type.AND,
+    "or": TokenSpec.Type.OR,
+
+    # operadores compuestos
+    "==": TokenSpec.Type.EQ,
+    "!=": TokenSpec.Type.NEQ,
+    "<=": TokenSpec.Type.LE,
+    ">=": TokenSpec.Type.GE,
+
+    # operadores y símbolos simples
+    "=": TokenSpec.Type.ASSIGN,
+    "+": TokenSpec.Type.PLUS,
+    "-": TokenSpec.Type.MINUS,
+    "*": TokenSpec.Type.MULT,
+    "/": TokenSpec.Type.DIV,
+    "<": TokenSpec.Type.LT,
+    ">": TokenSpec.Type.GT,
+    ":": TokenSpec.Type.COLON,
+    ",": TokenSpec.Type.COMMA,
+    "{": TokenSpec.Type.LBRACE,
+    "}": TokenSpec.Type.RBRACE,
+    "[": TokenSpec.Type.LBRACKET,
+    "]": TokenSpec.Type.RBRACKET,
+    "(": TokenSpec.Type.LPAREN,
+    ")": TokenSpec.Type.RPAREN,
+    ";": TokenSpec.Type.SEMICOLON,
+
+    # video-funciones
+    "@resize": TokenSpec.Type.VIDEO_RESIZE,
+    "@flip": TokenSpec.Type.VIDEO_FLIP,
+    "@velocidad": TokenSpec.Type.VIDEO_VELOCIDAD,
+    "@fadein": TokenSpec.Type.VIDEO_FADEIN,
+    "@fadeout": TokenSpec.Type.VIDEO_FADEOUT,
+    "@silencio": TokenSpec.Type.VIDEO_SILENCIO,
+    "@extraer_audio": TokenSpec.Type.VIDEO_EXTRAER_AUDIO,
+    "@quitar_audio": TokenSpec.Type.VIDEO_QUITAR_AUDIO,
+    "@agregar_musica": TokenSpec.Type.VIDEO_AGREGAR_MUSICA,
+    "@concatenar": TokenSpec.Type.VIDEO_CONCATENAR,
+    "@cortar": TokenSpec.Type.VIDEO_CORTAR,
+}
+
+
+@dataclass(frozen=True)
 class Token:
     type: TokenSpec.Type
     value: str
@@ -82,3 +144,21 @@ class Token:
 
     def __str__(self) -> str:
         return f"{self.type.name:20} [ {self.value} ] -> {self.line}:{self.column}"
+
+
+# Alias para facilitar el acceso desde otros módulos
+TokenType = TokenSpec.Type
+
+# Tablas derivadas útiles para el lexer
+KEYWORDS = {k: v for k, v in LEXEME_TO_TOKEN.items() if k.isalpha()}
+compound_ops = {
+    k: v
+    for k, v in LEXEME_TO_TOKEN.items()
+    if len(k) == 2 and not k.isalpha() and not k.startswith('@')
+}
+symbols = {
+    k: v
+    for k, v in LEXEME_TO_TOKEN.items()
+    if len(k) == 1 and not k.isalnum()
+}
+VIDEO_FUNCS = {k: v for k, v in LEXEME_TO_TOKEN.items() if k.startswith('@')}

--- a/lexer.py
+++ b/lexer.py
@@ -1,1 +1,283 @@
+import sys
+from typing import List
+from enums import (
+    TokenSpec,
+    Token,
+    TokenType,
+    KEYWORDS,
+    symbols,
+    compound_ops,
+    VIDEO_FUNCS,
+)
 
+class Lexer:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 0
+        self.line = 1
+        self.column = 1
+        self.errors: List[str] = []
+
+    def _peek(self) -> str:
+        return self.text[self.pos] if self.pos < len(self.text) else ''
+
+    def _advance(self) -> str:
+        ch = self._peek()
+        if ch:
+            self.pos += 1
+            if ch == '\n':
+                self.line += 1
+                self.column = 1
+            else:
+                self.column += 1
+        return ch
+
+    def _match(self, expected: str) -> bool:
+        if self.text.startswith(expected, self.pos):
+            for _ in expected:
+                self._advance()
+            return True
+        return False
+
+    def _skip_whitespace(self) -> None:
+        while True:
+            ch = self._peek()
+            if ch == '':
+                break
+            if ch in ' \t\r\n':
+                self._advance()
+            else:
+                break
+
+    def _number(self) -> Token:
+        start_pos = self.pos
+        start_line = self.line
+        start_col = self.column
+        has_dot = False
+        while True:
+            ch = self._peek()
+            if ch.isdigit():
+                self._advance()
+            elif ch == '.':
+                if has_dot:
+                    # malformed number like 1.2.3
+                    while self._peek().isdigit() or self._peek() == '.':
+                        self._advance()
+                    lex = self.text[start_pos:self.pos]
+                    self.errors.append(f"Malformed number '{lex}' at line {start_line}, column {start_col}")
+                    return None
+                has_dot = True
+                self._advance()
+            else:
+                break
+
+        lex = self.text[start_pos:self.pos]
+        # identifier starting with digit
+        nxt = self._peek()
+        if nxt.isalpha() or nxt == '_':
+            while self._peek().isalnum() or self._peek() == '_':
+                self._advance()
+            lex = self.text[start_pos:self.pos]
+            self.errors.append(f"Invalid identifier '{lex}' at line {start_line}, column {start_col}")
+            return None
+
+        token_type = TokenType.FLOAT_LITERAL if has_dot else TokenType.INT_LITERAL
+        return Token(token_type, lex, start_line, start_col)
+
+    def _string(self) -> Token:
+        start_line = self.line
+        start_col = self.column
+        start_index = self.pos
+        self._advance()  # consume opening quote
+        while True:
+            ch = self._peek()
+            if ch == '':
+                self.errors.append(f"Unterminated string at line {start_line}, column {start_col}")
+                return None
+            if ch == '"':
+                self._advance()  # consume closing quote
+                lex = self.text[start_index:self.pos]
+                return Token(TokenType.STRING_LITERAL, lex, start_line, start_col)
+            if ch == '\n':
+                self.errors.append(f"Unterminated string at line {start_line}, column {start_col}")
+                return None
+            self._advance()
+
+    def _identifier(self) -> Token:
+        start_pos = self.pos
+        start_line = self.line
+        start_col = self.column
+        while self._peek().isalnum() or self._peek() == '_':
+            self._advance()
+        lex = self.text[start_pos:self.pos]
+        token_type = KEYWORDS.get(lex, TokenType.IDENTIFIER)
+        return Token(token_type, lex, start_line, start_col)
+
+    def _video_function(self) -> Token:
+        start_line = self.line
+        start_col = self.column
+        self._advance()  # consume '@'
+        if not (self._peek().isalpha() or self._peek() == '_'):
+            invalid = '@' + self._peek()
+            self.errors.append(
+                f"Invalid character '{invalid}' at line {start_line}, column {start_col}"
+            )
+            if self._peek():
+                self._advance()
+            return None
+
+        start = self.pos
+        while self._peek().isalnum() or self._peek() == '_':
+            self._advance()
+        name = self.text[start:self.pos]
+        lex = '@' + name
+        token_type = VIDEO_FUNCS.get(lex)
+        if token_type is None:
+            self.errors.append(
+                f"Invalid character '{lex}' at line {start_line}, column {start_col}"
+            )
+            return None
+        return Token(token_type, lex, start_line, start_col)
+
+    def tokenize(self) -> List[Token]:
+        tokens: List[Token] = []
+        while self.pos < len(self.text):
+            self._skip_whitespace()
+            if self.pos >= len(self.text):
+                break
+
+            ch = self._peek()
+            start_line = self.line
+            start_col = self.column
+
+            if ch == '/' and self.text.startswith('//', self.pos):
+                # skip comment
+                while self._peek() and self._peek() != '\n':
+                    self._advance()
+                continue
+            if ch == '/' and self.text.startswith('/*', self.pos):
+                self.errors.append(f"Malformed comment at line {start_line}, column {start_col}")
+                self._advance()
+                self._advance()
+                while self._peek():
+                    if self.text.startswith('*/', self.pos):
+                        self._advance()
+                        self._advance()
+                        break
+                    if self._peek() == '\n':
+                        break
+                    self._advance()
+                continue
+
+            if ch.isdigit():
+                tok = self._number()
+                if tok:
+                    tokens.append(tok)
+                continue
+
+            if ch == '"':
+                tok = self._string()
+                if tok:
+                    tokens.append(tok)
+                continue
+
+            if ch.isalpha() or ch == '_':
+                tok = self._identifier()
+                if tok:
+                    tokens.append(tok)
+                continue
+
+            if ch == '@':
+                tok = self._video_function()
+                if tok:
+                    tokens.append(tok)
+                continue
+
+            # Compound operators
+            two = self.text[self.pos:self.pos+2]
+            if two in compound_ops:
+                self._advance()
+                self._advance()
+                tokens.append(Token(compound_ops[two], two, start_line, start_col))
+                continue
+
+            # Single character tokens and operators
+            if ch in symbols:
+                self._advance()
+                tokens.append(Token(symbols[ch], ch, start_line, start_col))
+                continue
+            if ch == '+':
+                self._advance()
+                # treat ++ as two plus tokens
+                if self._peek() == '+':
+                    tokens.append(Token(TokenType.PLUS, '+', start_line, start_col))
+                    start_col = self.column
+                    self._advance()
+                    tokens.append(Token(TokenType.PLUS, '+', start_line, start_col))
+                else:
+                    tokens.append(Token(TokenType.PLUS, '+', start_line, start_col))
+                continue
+            if ch == '-':
+                self._advance()
+                tokens.append(Token(TokenType.MINUS, '-', start_line, start_col))
+                continue
+            if ch == '*':
+                self._advance()
+                tokens.append(Token(TokenType.MULT, '*', start_line, start_col))
+                continue
+            if ch == '/':
+                self._advance()
+                tokens.append(Token(TokenType.DIV, '/', start_line, start_col))
+                continue
+            if ch == '=':
+                self._advance()
+                tokens.append(Token(TokenType.ASSIGN, '=', start_line, start_col))
+                continue
+            if ch == '<':
+                self._advance()
+                tokens.append(Token(TokenType.LT, '<', start_line, start_col))
+                continue
+            if ch == '>':
+                self._advance()
+                tokens.append(Token(TokenType.GT, '>', start_line, start_col))
+                continue
+            if ch == '!':
+                self._advance()
+                tokens.append(Token(TokenType.ERROR, '!', start_line, start_col))
+                self.errors.append(f"Invalid character '!' at line {start_line}, column {start_col}")
+                continue
+
+            # unrecognized character
+            self.errors.append(f"Invalid character '{ch}' at line {start_line}, column {start_col}")
+            self._advance()
+
+        tokens.append(Token(TokenType.EOF, '', self.line, self.column))
+        return tokens
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Uso: python lexer.py <archivo.txt>")
+        return
+    ruta = sys.argv[1]
+    try:
+        src = open(ruta, encoding='utf-8').read()
+    except FileNotFoundError:
+        print(f"Error: no existe '{ruta}'")
+        return
+    lexer = Lexer(src)
+    tokens = lexer.tokenize()
+    print("--- TOKENS ---")
+    for t in tokens:
+        if t.type == TokenType.EOF:
+            print("EOF")
+        else:
+            print(f"{t.type.name:15} [ {t.value} ] -> {t.line}:{t.column}")
+    if lexer.errors:
+        print("\n--- LEXICAL ERRORS ---")
+        for err in lexer.errors:
+            print(err)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- centralize token lookup tables in `enums.py`
- import the tables in `lexer.py`
- implement unified lexeme mapping and improve error detection

## Testing
- `python3 lexer.py prueba.txt`
- `python3 lexer.py error.txt` *(manual test added then removed)*
- `python3 parse_tree.py prueba.txt` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_685780b46fc48333a1362a0b3d24fcd3